### PR TITLE
Use `#{` and `#}` as delimiter and ignore operator `:`.

### DIFF
--- a/braces/register_codec.py
+++ b/braces/register_codec.py
@@ -17,14 +17,17 @@ class BracesStreamReader(utf_8.StreamReader):
         # Ignore indenting
         if tok_type in (tokenize.INDENT, tokenize.DEDENT):
             return
+        # Ignore `:`
+        if tok_type == tokenize.OP and tok_str == ':':
+            return
 
-        if tok_type == tokenize.OP:
-            if tok_str == '{':
+        if tok_type == tokenize.COMMENT:
+            if tok_str == '#{' or tok_str == '# {':
                 tok_type = tokenize.INDENT
                 self._indent += 1
                 tok_str = '  ' * self._indent
                 self._tokens.append((tokenize.COLON, ':'))
-            elif tok_str == '}':
+            elif tok_str == '#}' or tok_str == '# }':
                 tok_type = tokenize.DEDENT
                 self._indent -= 1
 

--- a/examples/arith.py
+++ b/examples/arith.py
@@ -1,16 +1,16 @@
 # coding: braces
 
-def foo(x, y) {
+def foo(x, y) #{
     return x + y
-}
+#}
 
-def main() {
-    for i in range(10) {
+def main() #{
+    for i in range(10) #{
         print "%s, %s" % (i * 2,
             i * 3)
-    }
-}
+    #}
+#}
 
-if __name__ == '__main__' {
+if __name__ == '__main__' #{
     main()
-}
+#}

--- a/examples/comments_and_string.py
+++ b/examples/comments_and_string.py
@@ -1,0 +1,8 @@
+# coding: braces
+
+def hello(): #{
+    print(1) # `#{` should not be recognized as  delimiter.
+    print(2)
+    # `#}` too.
+#}
+

--- a/examples/hashmap.py
+++ b/examples/hashmap.py
@@ -1,0 +1,9 @@
+# coding: braces
+
+hashmap = #{
+  'a': 2,
+  'aa': 3
+#}
+
+print(hashmap)
+

--- a/examples/noindent.py
+++ b/examples/noindent.py
@@ -1,16 +1,16 @@
 # coding: braces
 
-def foo(x, y) {
+def foo(x, y) #{
 return x + y
-}
+#}
 
-def main() {
-for i in range(10) {
+def main() #{
+for i in range(10) #{
 print "%s, %s" % (i * 2,
 i * 3)
-}
-}
+#}
+#}
 
-if __name__ == '__main__' {
+if __name__ == '__main__' #{
 main()
-}
+#}

--- a/examples/pep8.py
+++ b/examples/pep8.py
@@ -1,0 +1,3 @@
+def hello(): # {
+  print("hello")
+# }


### PR DESCRIPTION
Thus if the code itself is properly indented, it works with
current IDEs/editors.

Besides `#{` and `#}`, `# {` and `# }` is also supported to work
with PEP 8 "inline comments should start with `# `".

It also fix #1